### PR TITLE
Fix crash in audio source

### DIFF
--- a/src/DateTimeSources.cpp
+++ b/src/DateTimeSources.cpp
@@ -17,7 +17,9 @@ std::shared_ptr<DateSource> DateSource::Create() {
 }
 
 void DateSource::Evaluate() {
-    // TODO: Check dirty
+    // TODO: To save some redraws the redraw flag should check if date has changed since last draw
+    m_published = true;  // No need to publish
+    m_drawn = false;
 }
 
 std::shared_ptr<TimeSource> TimeSource::Create(MainLoop& mainLoop,
@@ -53,7 +55,8 @@ bool TimeSource::OnRead() {
         // Either block or no events
         return false;
     }
-    m_sourceDirtyFlag = true;
+    m_published = true;  // No need to publish
+    m_drawn = false;
     m_dateSource->Evaluate();
-    return m_sourceDirtyFlag;
+    return !m_drawn;
 }

--- a/src/DateTimeSources.h
+++ b/src/DateTimeSources.h
@@ -8,6 +8,7 @@ class DateSource : public Source {
     static std::shared_ptr<DateSource> Create();
     void Evaluate();
     virtual ~DateSource() {}
+    void Publish(const std::string_view, ScriptContext&) override {}
 
    private:
     DateSource() {}
@@ -19,6 +20,7 @@ class TimeSource : public Source, public IoHandler {
                                               std::shared_ptr<DateSource> dateSource);
     virtual ~TimeSource();
     virtual bool OnRead() override;
+    void Publish(const std::string_view, ScriptContext&) override {}
 
    private:
     TimeSource(int fd, std::shared_ptr<DateSource> dateSource)

--- a/src/MainLoop.cpp
+++ b/src/MainLoop.cpp
@@ -52,10 +52,8 @@ void MainLoop::Run() {
                 }
             }
         }
-        if (anyDirty) {
-            for (auto& handler : m_batchHandlers) {
-                handler->OnBatchProcessed();
-            }
+        if (anyDirty && m_batchHandler) {
+            m_batchHandler->OnBatchProcessed();
         }
     } while (m_polls.size() > 0);
 }
@@ -66,8 +64,11 @@ void MainLoop::Register(int fd, const std::string_view name, std::shared_ptr<IoH
     spdlog::debug("Registering {} in main loop for fd {}", name, fd);
 }
 
-void MainLoop::RegisterBatchHandler(std::shared_ptr<IoBatchHandler> ioBatchHandler) {
-    m_batchHandlers.push_back(ioBatchHandler);
+void MainLoop::RegisterBatchHandler(std::shared_ptr<IoBatchHandler> batchHandler) {
+    if (m_batchHandler) {
+        spdlog::error("Only one batch handler supported");
+    }
+    m_batchHandler = batchHandler;
 }
 
 void MainLoop::Wakeup() {

--- a/src/MainLoop.h
+++ b/src/MainLoop.h
@@ -38,5 +38,5 @@ class MainLoop {
     std::mutex m_wakupMutex;
     std::vector<pollfd> m_polls;
     std::map<int, std::shared_ptr<IoHandler>> m_handlers;
-    std::vector<std::shared_ptr<IoBatchHandler>> m_batchHandlers;
+    std::shared_ptr<IoBatchHandler> m_batchHandler;
 };

--- a/src/Manager.h
+++ b/src/Manager.h
@@ -5,35 +5,26 @@
 #include "src/ScriptContext.h"
 #include "src/Sources.h"
 
-class Manager : public IoBatchHandler, public Source {
+class Manager : public IoBatchHandler {
    public:
-    static std::shared_ptr<Manager> Create(std::shared_ptr<Registry> registry,
-                                           std::string_view sourceName, MainLoop& mainLoop,
-                                           std::unique_ptr<Sources> sources,
-                                           std::shared_ptr<ScriptContext> scriptContext);
+    static std::shared_ptr<Manager> Create(std::shared_ptr<Registry> registry);
+    void SetSources(std::unique_ptr<Sources> sources) { m_sources = std::move(sources); }
     virtual ~Manager() {}
-    // When a batch of IO events has been processed and sources are potentially dirty
+    // When a batch of IO events has been processed and sources needs to be published and/or needs
+    // to redrawn
     void OnBatchProcessed() override;
 
-    // Used by compositor implementation
+    // Compositors tells manager when the overlays should be visible
     void Show();
     void Hide();
-    void Publish(const Displays& displays);
 
     void ClickSurface(wl_surface* surface, int x, int y);
 
    private:
-    Manager(std::shared_ptr<Registry> registry, std::string_view sourceName,
-            std::unique_ptr<Sources> sources, std::shared_ptr<ScriptContext> scriptContext)
-        : m_registry(registry),
-          m_sourceName(sourceName),
-          m_sources(std::move(sources)),
-          m_scriptContext(scriptContext) {}
+    Manager(std::shared_ptr<Registry> registry) : m_registry(registry) {}
 
     std::shared_ptr<Registry> m_registry;
-    std::string m_sourceName;
     bool m_isVisible;
     bool m_visibilityChanged;
     std::unique_ptr<Sources> m_sources;
-    std::shared_ptr<ScriptContext> m_scriptContext;
 };

--- a/src/NetworkSource.h
+++ b/src/NetworkSource.h
@@ -8,19 +8,16 @@
 
 class NetworkSource : public Source, public IoHandler {
    public:
-    static std::shared_ptr<NetworkSource> Create(std::string_view name, MainLoop& mainLoop,
-                                                 std::shared_ptr<ScriptContext> scriptContext);
+    static std::shared_ptr<NetworkSource> Create(MainLoop& mainLoop);
     void Initialize();
     void ReadState();
     virtual bool OnRead() override;
+    void Publish(const std::string_view sourceName, ScriptContext& scriptContext) override;
     virtual ~NetworkSource() { close(m_timerfd); }
 
    private:
-    NetworkSource(std::string_view name, int socket, int timerfd,
-                  std::shared_ptr<ScriptContext> scriptContext)
-        : m_name(name), m_socket(socket), m_timerfd(timerfd), m_scriptContext(scriptContext) {}
+    NetworkSource(int socket, int timerfd) : m_socket(socket), m_timerfd(timerfd) {}
 
-    const std::string m_name;
     int m_socket;
     int m_timerfd;
     std::shared_ptr<ScriptContext> m_scriptContext;

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -132,7 +132,7 @@ void Outputs::Draw(const Registry &registry, const Sources &sources) {
     for (const auto &panelConfig : m_config->panels) {
         bool dirty = false;
         for (const auto &widgetConfig : panelConfig.widgets) {
-            if (sources.IsDirty(widgetConfig.sources)) {
+            if (sources.NeedsRedraw(widgetConfig.sources)) {
                 dirty = true;
                 break;
             }

--- a/src/PowerSource.h
+++ b/src/PowerSource.h
@@ -8,21 +8,18 @@
 
 class PowerSource : public Source, public IoHandler {
    public:
-    static std::shared_ptr<PowerSource> Create(std::string_view name, MainLoop& mainLoop,
-                                               std::shared_ptr<ScriptContext> scriptContext);
+    static std::shared_ptr<PowerSource> Create(MainLoop& mainLoop);
     bool Initialize();
     void ReadState();
     virtual bool OnRead() override;
+    void Publish(const std::string_view sourceName, ScriptContext& scriptContext) override;
     virtual ~PowerSource();
 
    private:
-    PowerSource(std::string_view name, int fd, std::shared_ptr<ScriptContext> scriptContext)
-        : m_name(name), m_timerfd(fd), m_scriptContext(scriptContext) {}
-    const std::string m_name;
+    PowerSource(int fd) : m_timerfd(fd) {}
     std::filesystem::path m_batteryCapacity;
     std::filesystem::path m_batteryStatus;
     std::filesystem::path m_ac;
     int m_timerfd;
-    std::shared_ptr<ScriptContext> m_scriptContext;
     PowerState m_sourceState;
 };

--- a/src/PulseAudioSource.h
+++ b/src/PulseAudioSource.h
@@ -11,34 +11,25 @@ struct pa_threaded_mainloop;
 struct pa_mainloop_api;
 struct pa_server_info;
 struct pa_sink_info;
-struct pa_source_info;
 
 class PulseAudioSource : public Source {
    public:
-    static std::unique_ptr<PulseAudioSource> Create(std::string_view name,
-                                                    std::shared_ptr<MainLoop> zenMainloop,
-                                                    std::shared_ptr<ScriptContext> scriptContext);
+    static std::unique_ptr<PulseAudioSource> Create(std::shared_ptr<MainLoop> zenMainloop);
     virtual ~PulseAudioSource();
 
     void OnStateChange();
     void OnServerChange(const pa_server_info*);
     void OnSinkChange(const pa_sink_info*);
+    void Publish(const std::string_view sourceName, ScriptContext& scriptContext) override;
 
    private:
-    PulseAudioSource(std::string_view name, std::shared_ptr<MainLoop> mainloop,
-                     pa_threaded_mainloop* mainLoop, std::shared_ptr<ScriptContext> scriptContext,
+    PulseAudioSource(std::shared_ptr<MainLoop> mainloop, pa_threaded_mainloop* mainLoop,
                      pa_mainloop_api* api, pa_context* ctx)
-        : m_name(name),
-          m_zenMainloop(mainloop),
-          m_mainLoop(mainLoop),
-          m_scriptContext(scriptContext),
-          m_api(api),
-          m_ctx(ctx) {}
-    const std::string m_name;
+        : m_zenMainloop(mainloop), m_mainLoop(mainLoop), m_api(api), m_ctx(ctx) {}
     std::shared_ptr<MainLoop> m_zenMainloop;
     pa_threaded_mainloop* m_mainLoop;
-    std::shared_ptr<ScriptContext> m_scriptContext;
     pa_mainloop_api* m_api;
     pa_context* m_ctx;
     AudioState m_sourceState;
+    std::mutex m_mutex;
 };

--- a/src/Seat.cpp
+++ b/src/Seat.cpp
@@ -45,6 +45,7 @@ static const wl_pointer_listener pointer_listener = {
     .axis_source = nullptr,
     .axis_stop = nullptr,
     .axis_discrete = nullptr,
+    // Version > supported
     //.axis_value120 = nullptr,
     //.axis_relative_direction = nullptr,
 };
@@ -102,18 +103,17 @@ std::unique_ptr<Keyboard> Keyboard::Create(std::shared_ptr<MainLoop> mainloop, w
 }
 
 void Keyboard::SetLayout(const char* layout) {
-    m_sourceDirtyFlag = m_sourceState.layout != layout;
-    if (m_sourceDirtyFlag) {
+    if (m_sourceState.layout != layout) {
+        m_drawn = m_published = false;
         m_sourceState.layout = layout;
-        if (m_scriptContext) m_scriptContext->Publish(m_sourceName, m_sourceState);
         m_mainloop->Wakeup();
     }
 }
-void Keyboard::SetScriptContext(const std::string_view sourceName,
-                                std::shared_ptr<ScriptContext> scriptContext) {
-    m_sourceName = sourceName;
-    m_scriptContext = scriptContext;
-    m_scriptContext->Publish(m_sourceName, m_sourceState);
+
+void Keyboard::Publish(const std::string_view sourceName, ScriptContext& scriptContext) {
+    if (m_published) return;
+    scriptContext.Publish(sourceName, m_sourceState);
+    m_published = true;
 }
 
 std::unique_ptr<Seat> Seat::Create(std::shared_ptr<MainLoop> mainLoop, wl_seat* wlseat) {

--- a/src/Seat.h
+++ b/src/Seat.h
@@ -21,15 +21,12 @@ class Keyboard : public Source {
     }
     static std::unique_ptr<Keyboard> Create(std::shared_ptr<MainLoop> mainloop, wl_seat* seat);
     void SetLayout(const char* layout);
-    void SetScriptContext(const std::string_view name,
-                          std::shared_ptr<ScriptContext> scriptContext);
+    void Publish(const std::string_view sourceName, ScriptContext& scriptContext) override;
 
    private:
     std::shared_ptr<MainLoop> m_mainloop;
     wl_keyboard* m_wlkeyboard;
     KeyboardState m_sourceState;
-    std::string m_sourceName;
-    std::shared_ptr<ScriptContext> m_scriptContext;
 };
 
 class Pointer {

--- a/src/Sources.h
+++ b/src/Sources.h
@@ -5,27 +5,36 @@
 #include <set>
 #include <string>
 
+#include "src/ScriptContext.h"
+
 class Source {
    public:
-    virtual bool IsSourceDirty() const { return m_sourceDirtyFlag; }
-    virtual void CleanDirtySource() { m_sourceDirtyFlag = false; }
-    virtual void ForceDirtySource() { m_sourceDirtyFlag = true; }
+    void SetDrawn() { m_drawn = true; }
+    void ClearDrawn() { m_drawn = false; }
+    bool IsDrawn() { return m_drawn; }
+
+    virtual void Publish(const std::string_view sourceName, ScriptContext& scriptContext) = 0;
     virtual ~Source() {}
 
    protected:
-    bool m_sourceDirtyFlag;
+    bool m_drawn;      // Set to false to indicate that source needs to be redrawn
+    bool m_published;  // Set to false to indicate that there is a new state to be published
 };
 
 // Maintains set of sources
 class Sources {
    public:
-    static std::unique_ptr<Sources> Create();
+    static std::unique_ptr<Sources> Create(std::unique_ptr<ScriptContext> scriptContext);
     void Register(std::string_view name, std::shared_ptr<Source> source);
     bool IsRegistered(const std::string& name) { return m_sources.find(name) != m_sources.end(); }
-    void CleanAll();
-    void DirtyAll();
-    bool IsDirty(const std::set<std::string> sources) const;
+    void SetAllDrawn();
+    void ForceRedraw();
+    bool NeedsRedraw(const std::set<std::string> sources) const;
+    void PublishAll();
 
    private:
+    Sources(std::unique_ptr<ScriptContext> scriptContext)
+        : m_scriptContext(std::move(scriptContext)) {}
     std::map<std::string, std::shared_ptr<Source>> m_sources;
+    std::unique_ptr<ScriptContext> m_scriptContext;
 };

--- a/src/SwayCompositor.h
+++ b/src/SwayCompositor.h
@@ -3,20 +3,23 @@
 #include <memory>
 
 #include "MainLoop.h"
-#include "src/Manager.h"
+#include "src/Sources.h"
 
-class SwayCompositor : public IoHandler {
+using Visibility = std::function<void(bool visibility)>;
+
+class SwayCompositor : public IoHandler, public Source {
    public:
-    static std::shared_ptr<SwayCompositor> Connect(MainLoop& mainLoop,
-                                                   std::shared_ptr<Manager> manager);
+    static std::shared_ptr<SwayCompositor> Connect(MainLoop& mainLoop, Visibility visibility);
     virtual ~SwayCompositor();
 
     virtual bool OnRead() override;
+    void Publish(const std::string_view sourceName, ScriptContext& scriptContext) override;
 
    private:
     void Initialize();
-    SwayCompositor(int fd, std::shared_ptr<Manager> manager) : m_fd(fd), m_manager(manager) {}
+    SwayCompositor(int fd, Visibility visibility) : m_fd(fd), m_visibility(visibility) {}
     int m_fd;
-    std::shared_ptr<Manager> m_manager;
     std::string m_payload;
+    Displays m_displays;
+    Visibility m_visibility;
 };


### PR DESCRIPTION
Pulse Audio source is currently the only source that has its own thread to poll for changes. Embedded Lua is not thread safe so at some cases publishing audio source changes on that thread caused the program to crash. This refactors to make sure that publishing of source states to Lua always happens on main thread.