### PR TITLE
Provide empty implementations in wl_ handlers

### DIFF
--- a/src/Seat.cpp
+++ b/src/Seat.cpp
@@ -110,14 +110,20 @@ static void on_keymap(void* data, struct wl_keyboard*, uint32_t format, int32_t 
     xkb_context_unref(ctx);
 }
 
-void on_repeat_info(void* /*data*/, struct wl_keyboard*, int32_t /*rate*/, int32_t /*delay*/) {}
+static void on_enter(void*, struct wl_keyboard*, uint32_t, struct wl_surface*, struct wl_array*) {}
+
+static void on_leave(void*, struct wl_keyboard*, uint32_t, struct wl_surface*) {}
+static void on_key(void*, struct wl_keyboard*, uint32_t, uint32_t, uint32_t, uint32_t) {}
+static void on_modifiers(void*, struct wl_keyboard*, uint32_t, uint32_t, uint32_t, uint32_t,
+                         uint32_t) {}
+static void on_repeat_info(void*, struct wl_keyboard*, int32_t, int32_t) {}
 
 static const wl_keyboard_listener keyboard_listener = {
     .keymap = on_keymap,
-    .enter = nullptr,
-    .leave = nullptr,
-    .key = nullptr,
-    .modifiers = nullptr,
+    .enter = on_enter,
+    .leave = on_leave,
+    .key = on_key,
+    .modifiers = on_modifiers,
     .repeat_info = on_repeat_info,
 };
 

--- a/src/ShellSurface.cpp
+++ b/src/ShellSurface.cpp
@@ -20,11 +20,13 @@ static void on_closed(void *data, struct zwlr_layer_surface_v1 *) {
 
 static void on_enter(void * /*data*/, struct wl_surface *, struct wl_output *) {}
 
+static void on_leave(void * /*data*/, struct wl_surface *, struct wl_output *) {}
+
 static const zwlr_layer_surface_v1_listener layer_listener = {.configure = on_configure,
                                                               .closed = on_closed};
 
 static const wl_surface_listener surface_listener = {
-    .enter = on_enter, .leave = nullptr,
+    .enter = on_enter, .leave = on_leave,
     //.preferred_buffer_scale = nullptr,
     //.preferred_buffer_transform = nullptr,
 };


### PR DESCRIPTION
Handlers seems to be invoked regardless if they are null or not.

Add an empty impl of all handlers.